### PR TITLE
feat(cli): add translate command

### DIFF
--- a/honeybee_vtk/cli.py
+++ b/honeybee_vtk/cli.py
@@ -1,0 +1,67 @@
+"""Honeybee VTK command line interface."""
+import sys
+import pathlib
+
+import click
+from click.exceptions import ClickException
+
+from .write import write_vtk
+
+
+@click.group()
+def main():
+    """Honeybee VTK commands entry point."""
+    pass
+
+
+@main.command('translate')
+@click.argument('hbjson-file')
+@click.option(
+    '--name', '-n', help='Name of the output .zip file. If not provided, the name of '
+    'input HBJSON file will be used.'
+)
+@click.option(
+    '--folder', '-f', help='Path to target folder.',
+    type=click.Path(exists=False, file_okay=False, resolve_path=True, dir_okay='True'),
+    default='.', show_default=True
+)
+@click.option(
+    '--vtk/--xml', is_flag=True, default=True, help='Switch between a vtk file format '
+    'and a xml file format. Default is vtk.', show_default=True
+)
+@click.option(
+    '--exclude-grids', '-eg', is_flag=True, default=False,
+    help='Flag to exclude exporting grids.', show_default=True
+)
+@click.option(
+    '--exclude-vectors', '-ev', is_flag=True, default=False,
+    help='Flag to exclude exporting vector lines.', show_default=True
+)
+def translate_recipe(hbjson_file, name, folder, vtk, exclude_grids, exclude_vectors):
+    """Translate a HBJSON file to several VTK files.
+
+    The output file is a zipped file that contains all the generated VTK files.
+
+    \b
+    Args:
+        hbjson-file: Path to input HBJSON file.
+
+    """
+
+    folder = pathlib.Path(folder)
+    folder.mkdir(exist_ok=True)
+    file_type = 'vtk' if vtk else 'xml'
+    include_grids = not exclude_grids
+    include_vectors = not exclude_vectors
+
+    try:
+        output_file = write_vtk(
+            hbjson_file, target_folder=folder, file_name=name,
+            include_grids=include_grids, include_vectors=include_vectors,
+            writer=file_type
+        )
+    except Exception as e:
+        raise ClickException(f'Translation to VTK failed:\n{e}')
+    else:
+        print(f'Success: {output_file}', file=sys.stderr)
+        return sys.exit(0)

--- a/honeybee_vtk/write.py
+++ b/honeybee_vtk/write.py
@@ -13,7 +13,7 @@ from .writers import _write_grids, _write_vectors
 from .writers import write_polydata
 
 
-def write_vtk(file_path, *, file_name=None, include_grids=True,
+def write_vtk(file_path, *, file_name=None, target_folder=None, include_grids=True,
               include_vectors=True, writer='vtk'):
     """Read a valid HBJSON and write a .zip of vtk files.
 
@@ -22,6 +22,8 @@ def write_vtk(file_path, *, file_name=None, include_grids=True,
         file_name: A text string for the name of the .zip file to be written. If no
             text string is provided, the name of the HBJSON file will be used as a
             file name for the .zip file.
+        target_folder: A text string to a folder to write the output file. The file
+            will be written to the current folder if not provided.
         include_grids: A boolean. Defaults to True. Grids will not be extracted from
             HBJSON if set to False.
         include_vectors: A boolean. Defaults to True. Vector arrows will not be created
@@ -97,10 +99,14 @@ def write_vtk(file_path, *, file_name=None, include_grids=True,
     if not file_name:
         name = '.'.join(os.path.basename(file_path).split('.')[:-1])
         file_name = clean_string(name)
-    zip_name = file_name
 
+    # remove extension if provided by user
+    file_name = file_name if not file_name.lower().endswith('.zip') else file_name[:-4]
+
+    target_folder = target_folder or os.getcwd()
+    zip_file = os.path.join(target_folder, file_name + '.zip')
     # Create a .zip file to capture all the generated .vtk files
-    zipobj = ZipFile(file_name + '.zip', 'w')
+    zipobj = ZipFile(zip_file, 'w')
 
     # Capture vtk files in a zip file.
     for file_name in file_names:
@@ -117,4 +123,4 @@ def write_vtk(file_path, *, file_name=None, include_grids=True,
                 ' You may please delete the .vtk files manually.'
             )
     # Return the path where the .zip file is written
-    return os.path.join(os.getcwd(), zip_name + '.zip')
+    return zip_file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ladybug-geometry==1.23.0
 honeybee-core==1.41.11
 vtk==9.0.1
+click==7.1.2

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 with open('requirements.txt') as f:
@@ -18,6 +18,9 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/honeybee-vtk",
     packages=setuptools.find_packages(exclude=["tests*"]),
     install_requires=requirements,
+    entry_points={
+        "console_scripts": ["honeybee-vtk = honeybee_vtk.cli:main"]
+    },
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Adds a command to translate HBJSON file to VTK. Here is an example.

`honeybee-vtk translate .\tests\assets\unnamed.hbjson -n named -f .\tests --vtk --exclude-vectors`

Try `honeybee-vtk translate --help` for all options

```
Usage: honeybee-vtk translate [OPTIONS] HBJSON_FILE

  Translate a HBJSON file to several VTK files.

  The output file is a zipped file that contains all the generated VTK
  files.

  Args:
      hbjson-file: Path to input HBJSON file.

Options:
  -n, --name TEXT         Name of the output .zip file. If not provided, the
                          name of input HBJSON file will be used.

  -f, --folder DIRECTORY  Path to target folder.  [default: .]
  --vtk / --xml           Switch between a vtk file format and a xml file
                          format. Default is vtk.  [default: True]

  -eg, --exclude-grids    Flag to exclude exporting grids.  [default: False]
  -ev, --exclude-vectors  Flag to exclude exporting vector lines.  [default:
                          False]

  --help                  Show this message and exit.
```

@devngc, I made some changes to write VTK to allow defining the target folder for output file. I didn't spend time to make sure the VTK files are also written to that folder before being deleted but I think that is the right way to do it.

I also didn't add tests. You can see an example [here](https://github.com/ladybug-tools/honeybee-radiance/blob/master/tests/cli/grid_cli_test.py) on how one can write test for CLI commands written using `click`.

This PR should also fix the deployment issue for docs.