### PR TITLE
docs(readme): add a link to the minimalist viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ honeybee-vtk translate "path to hbjson file" --folder="path to the target folder
 ## [API Documentation](https://www.ladybug.tools/honeybee-vtk/docs/)
 
 
-## Create arrows and write to a vtp file
+## Create arrows and write to a vtp file and open it in a minimalist desktop [viewer](https://kitware.github.io/F3D/)
 
 ```python
 from ladybug_geometry.geometry3d import Point3D, Vector3D
@@ -100,10 +100,9 @@ arrows = create_arrow(points, vectors)
 arrows.to_vtk('.', 'arrows')
 
 ```
-
 ![arrows](/images/arrows.png)
 
-## Create a group of points and color them based on distance from origin
+## Create a group of points and color them based on distance from origin, write them to a vtp file and and open it in a minimalist desktop [viewer](https://kitware.github.io/F3D/)
 
 ```python
 


### PR DESCRIPTION
It was unclear how the arrow and colored points images in readme were created. I spent sometime to figure out whether it was done using the scene module. Luckily, I was able to figure out that they are created using the F3D viewer. I added the link to the viewer to avoid confusion for a potential future reader.