### PR TITLE
fix default camera location

### DIFF
--- a/honeybee_vtk/assistant.py
+++ b/honeybee_vtk/assistant.py
@@ -2,7 +2,7 @@
 
 import vtk
 import pathlib
-from typing import List, Tuple
+from typing import Tuple
 from .actor import Actor
 from .camera import Camera
 from .types import ImageTypes

--- a/honeybee_vtk/camera.py
+++ b/honeybee_vtk/camera.py
@@ -34,7 +34,7 @@ class Camera(View):
     def __init__(
             self,
             identifier: str = 'camera',
-            position: Tuple[float, float, float] = (0, 0, 50),
+            position: Tuple[float, float, float] = (0, 0, 100),
             direction: Tuple[float, float, float] = (0, 0, -1),
             up_vector: Tuple[float, float, float] = (0, 1, 0),
             h_size: int = 60,

--- a/tests/camera_test.py
+++ b/tests/camera_test.py
@@ -15,7 +15,7 @@ def test_to_vtk():
     # Initialize a camera object and assess all the default properties
     camera = Camera()
     assert camera.identifier[0:6] == 'camera'
-    assert camera.position.value == (0, 0, 50)
+    assert camera.position.value == (0, 0, 100)
     assert camera.direction.value == (0, 0, -1)
     assert camera.up_vector.value == (0, 1, 0)
     assert camera.h_size.value == 60


### PR DESCRIPTION
honeybee-vtk cli adds a default camera to generate an image if no camera is found in hbjson. This PR optimizes the camera position.