### PR TITLE
Add default camera to cli

### DIFF
--- a/honeybee_vtk/actor.py
+++ b/honeybee_vtk/actor.py
@@ -145,3 +145,21 @@ class Actor:
             points.extend(min_max)
 
         return points
+
+    @staticmethod
+    def get_centroid(actors: List[Actor]) -> Point3D:
+        """Get Centroid of actors.
+
+        Args:
+            actors: A list of honeybee-vtk actor objects.
+
+        Returns:
+            Centroid as a Point3D object.
+        """
+        points = Actor.get_bounds(actors)
+
+        x = sum([point.x for point in points]) / len(points)
+        y = sum([point.y for point in points]) / len(points)
+        z = sum([point.z for point in points]) / len(points)
+
+        return (x, y, z)

--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -1,15 +1,19 @@
-from honeybee_vtk.actor import Actor
-from honeybee_vtk.scene import Scene
-from honeybee_vtk.camera import Camera
+
 
 import pathlib
 import sys
 import click
+from click import types
 from click.exceptions import ClickException
 
+from honeybee_vtk.actor import Actor
+from honeybee_vtk.scene import Scene
+from honeybee_vtk.camera import Camera
 from honeybee_vtk.model import Model
 from honeybee_vtk.vtkjs.schema import SensorGridOptions, DisplayMode
 from honeybee_vtk.types import ImageTypes
+from honeybee_vtk._helper import get_adjuested_centroid
+
 
 @click.group()
 def export():
@@ -122,7 +126,9 @@ def export(
 
         # Set a default camera if there are not cameras in the model
         if not model.cameras:
-            camera = Camera()
+            # Use the centroid of the model for the camera position
+            actors = Actor.from_model(model=model)
+            camera = Camera(position=Actor.get_centroid(actors), type='l')
             cameras = [camera]
         else:
             cameras = model.cameras

--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -3,7 +3,6 @@
 import pathlib
 import sys
 import click
-from click import types
 from click.exceptions import ClickException
 
 from honeybee_vtk.actor import Actor
@@ -12,7 +11,6 @@ from honeybee_vtk.camera import Camera
 from honeybee_vtk.model import Model
 from honeybee_vtk.vtkjs.schema import SensorGridOptions, DisplayMode
 from honeybee_vtk.types import ImageTypes
-from honeybee_vtk._helper import get_adjuested_centroid
 
 
 @click.group()


### PR DESCRIPTION
This PR adds a default camera to cli so that when `export-images` command is called on a model with no views, a default camera is used to export an image of the plan view.