### PR TITLE
fix(deploy): Fail on missing env vars

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,10 +17,8 @@ twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
 echo "Docker Deployment..."
 echo "Login to Docker"
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-
-docker build -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION --target main .
-docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
-
-docker push $CONTAINER_NAME:latest
-docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION
+echo "${DOCKER_PASSWORD:?}" | docker login -u "${DOCKER_USERNAME:?}" --password-stdin \
+  && docker build -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION --target main . \
+  && docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest \
+  && docker push $CONTAINER_NAME:latest \
+  && docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION


### PR DESCRIPTION
@mostaphaRoudsari can you double check that the secrets for docker are being supplied in the repo secrets? I'm not able to see them.

This change will fail the deploy script with a more useful error message if the docker credentials are missing.