### PR TITLE
Use radiance view dimension as image dimension

### DIFF
--- a/honeybee_vtk/assistant.py
+++ b/honeybee_vtk/assistant.py
@@ -124,7 +124,7 @@ class Assistant:
 
     def _export_image(
             self, folder: str, name: str, image_type: ImageTypes = ImageTypes.png, *,
-            image_scale: int = 1, image_width: int = 2000, image_height: int = 2000,
+            image_scale: int = 1, image_width=None, image_height=None,
             color_range: vtk.vtkLookupTable = None, rgba: bool = False,
             show: bool = False) -> str:
         """Export the window as an image.
@@ -139,9 +139,9 @@ class Assistant:
             image_type: An ImageType object.
             image_scale: An integer value as a scale factor. Defaults to 1.
             image_width: An integer value that sets the width of image in pixels.
-                Defaults to 2000.
+                Defaults to None.
             image_height: An integer value that sets the height of image in pixels.
-                Defaults to 2000.
+                Defaults to None.
             color_range: A vtk lookup table object which can be obtained
                 from the color_range mehtod of the DataFieldInfo object.
                 Defaults to None.
@@ -155,6 +155,12 @@ class Assistant:
         Returns:
             A text string representing the path to the image.
         """
+        # Using view's x and y dimension as image width and height
+        dim_x, dim_y = self._camera.dimension_x_y()
+        if not image_width:
+            image_width = dim_x
+        if not image_height:
+            image_height = dim_y
 
         # render window
         if not show:

--- a/honeybee_vtk/assistant.py
+++ b/honeybee_vtk/assistant.py
@@ -18,8 +18,8 @@ class Assistant:
     Args:
         background_color: A tuple of three integers that represent RGB values of the
             color that you'd like to set as the background color.
-        camera: A Camera object.
         actors: A dictionary of actors from a Scene object
+        camera: A Camera object.
         legend_parameters: A list of legend parameter objects to be added to the scene
     """
 
@@ -29,11 +29,7 @@ class Assistant:
         self._background_color = background_color
         self._actors = actors
         self._camera = camera
-        # interactor = None
-        # window = None
-        # renderer = None
         self._legend_params = legend_parameters
-        # self._create_window()
 
     def _create_window(self) -> None:
         """Create a rendering window with a single renderer and an interactor.

--- a/honeybee_vtk/assistant.py
+++ b/honeybee_vtk/assistant.py
@@ -59,6 +59,16 @@ class Assistant:
         if self._legend_params:
             for legend_param in self._legend_params:
                 if not legend_param.hide_legend:
+                    # If text size is not specified, use average of camera dimension to
+                    # arrive at a number. 2.5% of this number is used.
+                    text_size = round((
+                        (self._camera.dimension_x_y()[0] +
+                         self._camera.dimension_x_y()[1]) / 2) * 0.025)
+                    if legend_param.label_parameters.size == 0:
+                        legend_param.label_parameters.size = text_size
+                    if legend_param.title_parameters.size == 0:
+                        legend_param.title_parameters.size = text_size
+                    # Add legends to renderer
                     renderer.AddActor(legend_param.get_scalarbar())
 
         # add renderer to rendering window

--- a/honeybee_vtk/assistant.py
+++ b/honeybee_vtk/assistant.py
@@ -126,7 +126,7 @@ class Assistant:
             raise ValueError(f'Invalid image type: {image_type}')
         return writer
 
-    def auto_image_dimension(self, image_width, image_height) -> Tuple[int]:
+    def auto_image_dimension(self, image_width=None, image_height=None) -> Tuple[int]:
         """Calculate image dimension.
 
         If image width and image height are not specified by the user, Camera's x and y
@@ -134,8 +134,8 @@ class Assistant:
         its parent Radiance View object.
 
         Args:
-            image_width: Image width in pixels set by the user.
-            image_height: Image height in pixels set by the user.
+            image_width: Image width in pixels set by the user. Defaults to None.
+            image_height: Image height in pixels set by the user. Defaults to None.
 
         Returns:
             A tuple with two elements

--- a/honeybee_vtk/camera.py
+++ b/honeybee_vtk/camera.py
@@ -40,7 +40,7 @@ class Camera(View):
             direction: Tuple[float, float, float] = (0, 0, -1),
             up_vector: Tuple[float, float, float] = (0, 1, 0),
             h_size: int = 60,
-            v_size: int = 30,
+            v_size: int = 60,
             type: str = 'v') -> None:
 
         super().__init__(

--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -38,12 +38,12 @@ def export():
     help='choose the type of image file.', show_default=True
 )
 @click.option(
-    '--image-width', '-iw', type=int, default=2500, help='Width of images in pixels.',
-    show_default=True
+    '--image-width', '-iw', type=int, default=None, help='Width of images in pixels.'
+    ' If not set, Radiance default x dimension of view will be used.', show_default=True
 )
 @click.option(
-    '--image-height', '-ih', type=int, default=2000, help='Height of images in pixels.',
-    show_default=True
+    '--image-height', '-ih', type=int, default=None, help='Height of images in pixels.'
+    'If not set, Radiance default y dimension of view will be used.', show_default=True
 )
 @click.option(
     '--background-color', '-bc', type=(int, int, int), default=(255, 255, 255),

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -38,7 +38,7 @@ class TextConfig(BaseModel):
     )
 
     size: conint(ge=0) = Field(
-        30,
+        0,
         description='Text size in points.'
     )
 

--- a/honeybee_vtk/legend_parameter.py
+++ b/honeybee_vtk/legend_parameter.py
@@ -1,6 +1,5 @@
 """Vtk legend parameters."""
 
-from _pytest.python_api import raises
 import vtk
 from ladybug.color import Colorset, Color
 from enum import Enum, auto

--- a/honeybee_vtk/legend_parameter.py
+++ b/honeybee_vtk/legend_parameter.py
@@ -166,7 +166,7 @@ class Text:
     @size.setter
     def size(self, val) -> None:
         if not val:
-            self._size = 30
+            self._size = 0
         elif isinstance(val, int):
             self._size = val
         else:
@@ -272,8 +272,8 @@ class LegendParameter:
             label_count: int = None,
             decimal_count: DecimalCount = DecimalCount.default,
             preceding_labels: bool = False,
-            label_parameters: Text = Text(color=(0, 0, 0), size=30),
-            title_parameters: Text = Text(color=(0, 0, 0), size=50, bold=True),
+            label_parameters: Text = Text(color=(0, 0, 0), size=0),
+            title_parameters: Text = Text(color=(0, 0, 0), size=0, bold=True),
             min: Union[float, int] = None,
             max: Union[float, int] = None,
             auto_range: Tuple[float, float] = None) -> None:
@@ -512,7 +512,7 @@ class LegendParameter:
     @label_parameters.setter
     def label_parameters(self, val) -> None:
         if not val:
-            self._label_parameters = Text(color=(0, 0, 0), size=30)
+            self._label_parameters = Text()
         elif isinstance(val, Text):
             self._label_parameters = val
         else:
@@ -528,7 +528,7 @@ class LegendParameter:
     @title_parameters.setter
     def title_parameters(self, val) -> None:
         if not val:
-            self._title_parameters = Text(color=(0, 0, 0), size=30, bold=True)
+            self._title_parameters = Text(bold=True)
         elif isinstance(val, Text):
             self._title_parameters = val
         else:

--- a/tests/github/assistant_test.py
+++ b/tests/github/assistant_test.py
@@ -1,30 +1,60 @@
 """Unit test for assistants module."""
 
-from honeybee_vtk.scene import Scene
+from honeybee_vtk.legend_parameter import LegendParameter
 import pytest
 import vtk
 from honeybee_vtk.model import Model
 from honeybee_vtk.assistant import Assistant
 from honeybee_vtk.actor import Actor
 from honeybee_vtk.camera import Camera
+from honeybee_vtk.scene import Scene
+from honeybee_vtk.vtkjs.schema import SensorGridOptions
+from honeybee_vtk.config import load_config
 
 file_path = r'tests/assets/gridbased.hbjson'
+valid_json_path = r'tests/assets/config/valid.json'
+
+model = Model.from_hbjson(file_path, load_grids=SensorGridOptions.Sensors)
+actors = Actor.from_model(model)
+camera = Camera()
+scene = Scene()
+scene.add_actors(actors)
+scene.add_cameras(camera)
+
+load_config(valid_json_path, model, scene)
+
+scene.update_scene()
+assistant = scene.assistants[0]
 
 
 def test_initialization():
-    """Test objct initialization."""
-    model = Model.from_hbjson(hbjson=file_path)
-    actors = Actor.from_model(model=model)
-    camera = Camera()
-    scene = Scene()
-    scene.add_actors(actors)
-    scene.add_cameras(camera)
+    assert isinstance(assistant._actors, dict)
+    assert isinstance(assistant._legend_params[0], LegendParameter)
+    assert isinstance(assistant._camera, Camera)
+    assert isinstance(assistant._background_color, vtk.vtkColor3d)
 
-    assistant = Assistant(
-        background_color=(0, 0, 0), camera=camera, actors=scene._actors,
-        legend_parameters=scene.legend_parameters)
 
-    assert isinstance(assistant._interactor, vtk.vtkRenderWindowInteractor)
-    assert isinstance(assistant._window, vtk.vtkRenderWindow)
-    assert isinstance(assistant._renderer, vtk.vtkRenderer)
-    assert isinstance(assistant._legend_params, dict)
+def test_create_window():
+    interactor, window, renderer = assistant._create_window()
+    assert isinstance(interactor, vtk.vtkRenderWindowInteractor)
+    assert isinstance(window, vtk.vtkRenderWindow)
+    assert isinstance(renderer, vtk.vtkRenderer)
+
+
+def test_auto_image_dimension():
+    image_width, image_height = assistant.auto_image_dimension()
+    assert image_width == 512
+    assert image_height == 512
+
+    image_width, image_height = assistant.auto_image_dimension(2000, 2000)
+    assert image_width == 2000
+    assert image_height == 2000
+
+
+def test_auto_text_height():
+    image_width, image_height = assistant.auto_image_dimension()
+    assert assistant._legend_params[0].label_parameters.size == 0
+    assert assistant._legend_params[0].title_parameters.size == 0
+    assistant.auto_text_height(image_width, image_height)
+    assert assistant._legend_params[0].label_parameters.size == 13
+    assert assistant._legend_params[0].title_parameters.size == 13

--- a/tests/github/camera_test.py
+++ b/tests/github/camera_test.py
@@ -19,7 +19,7 @@ def test_to_vtk():
     assert camera.direction == (0, 0, -1)
     assert camera.up_vector == (0, 1, 0)
     assert camera.h_size == 60
-    assert camera.v_size == 30
+    assert camera.v_size == 60
     assert camera.type == 'v'
 
     # Assess type of the outcome of the to_vtk method

--- a/tests/github/config_test.py
+++ b/tests/github/config_test.py
@@ -29,7 +29,7 @@ def test_text_config_defaults():
     """Testting default settings of the TextConfig object."""
     text_config = TextConfig()
     assert text_config.color == [0, 0, 0]
-    assert text_config.size == 30
+    assert text_config.size == 0
     assert text_config.bold == False
 
 


### PR DESCRIPTION
This PR adds the capability of using a radiance view dimension to be the dimension of the exported images. If a user supplies `image_width` and/or `image_height`, it will override image dimension. 

I also added methods to auto calculate the text size of legend labels and legend titles if the user does not supply text size in legend parameters.

resolves #191 