### PR TITLE
Add default camera names

### DIFF
--- a/honeybee_vtk/assistant.py
+++ b/honeybee_vtk/assistant.py
@@ -38,6 +38,16 @@ class Assistant:
         A render is added to a window and then the window is set inside the interactor.
         This method returns a tuple of a window_interactor, a render_window, and a
         renderer.
+
+        Returns:
+            A tuple with three elements
+
+            -   interactor: A vtkRenderWindowInteractor object.
+
+            -   window: A vtkRenderWindow object.
+
+            -   renderer: A vtkRenderer object.
+
         """
         if not self._camera:
             raise ValueError(
@@ -72,8 +82,8 @@ class Assistant:
 
         renderer.SetActiveCamera(self._camera.to_vtk())
         renderer.ResetCamera()
+
         # the order is from outside to inside
-        # interactor, window, renderer = (interactor, window, renderer)
         return interactor, window, renderer
 
     def _export_gltf(self, folder: str, name: str) -> str:
@@ -168,7 +178,7 @@ class Assistant:
                 legend_param.title_parameters.size = text_size
 
     def _export_image(
-            self, folder: str, name: str, image_type: ImageTypes = ImageTypes.png, *,
+            self, folder: str, image_type: ImageTypes = ImageTypes.png, *,
             image_scale: int = 1, image_width=None, image_height=None,
             color_range: vtk.vtkLookupTable = None, rgba: bool = False,
             show: bool = False) -> str:
@@ -180,7 +190,6 @@ class Assistant:
 
         Args:
             folder: A valid path to where you'd like to write the image.
-            name: Name of the image as a text string.
             image_type: An ImageType object.
             image_scale: An integer value as a scale factor. Defaults to 1.
             image_width: An integer value that sets the width of image in pixels.
@@ -220,7 +229,8 @@ class Assistant:
             interactor.Initialize()
             interactor.Start()
 
-        image_path = pathlib.Path(folder, f'{name}.{image_type.value}')
+        image_path = pathlib.Path(
+            folder, f'{self._camera.identifier}.{image_type.value}')
         writer = self._get_image_writer(image_type)
         if image_type == ImageTypes.jpg:
             writer.SetQuality(100)  # image quality

--- a/honeybee_vtk/camera.py
+++ b/honeybee_vtk/camera.py
@@ -55,11 +55,9 @@ class Camera(View):
         if self._type.value == 'l':
             camera.SetParallelProjection(True)
             camera.ParallelProjectionOn()
-        # Perspective projection
-        else:
-            # The location of camera in a 3D space
-            camera.SetPosition(self._position.value)
 
+        # The location of camera in a 3D space
+        camera.SetPosition(self._position.value)
         # get a focal_point on the same axis as the camera position.
         fp = (self._position[0] + self._direction.value[0],
               self._position[1] + self._direction.value[1],
@@ -67,8 +65,13 @@ class Camera(View):
         # The direction to the point where the camera is looking at
         camera.SetFocalPoint(fp)
 
+        # calculate view normal to the camera
+        camera.ComputeViewPlaneNormal()
         # Where the top of the camera is
         camera.SetViewUp(self._up_vector.value)
+        # Make sure that view up is 90 degrees to the view normal
+        camera.OrthogonalizeViewUp()
+
         # Horizontal view angle
         camera.SetViewAngle(self._h_size.value)
         camera.SetUseHorizontalViewAngle(True)
@@ -87,6 +90,7 @@ class Camera(View):
             A Camera object.
         """
         return cls(
+            identifier=view.identifier,
             position=view.position,
             direction=view.direction,
             up_vector=view.up_vector,
@@ -164,12 +168,15 @@ class Camera(View):
         directions = [LineSegment3D.from_end_points(
             pt, centroid).v for pt in camera_points]
 
-        # create cameras from four points. These cameras must look at the centroid.
+        # default camera identifiers
+        names = ['45_degree', '225_degree', '180_degree', '135_degree']
+
+        # create cameras from four points. These cameras look at the centroid.
         default_cameras = []
         for i in range(len(camera_points)):
             point = camera_points[i]
             direction = directions[i]
-            default_cameras.append(cls(position=(point.x, point.y, point.z),
+            default_cameras.append(cls(identifier=names[i], position=(point.x, point.y, point.z),
                                        direction=(direction.x, direction.y, direction.z),
                                        up_vector=(0, 0, 1)))
 

--- a/honeybee_vtk/camera.py
+++ b/honeybee_vtk/camera.py
@@ -169,7 +169,7 @@ class Camera(View):
             pt, centroid).v for pt in camera_points]
 
         # default camera identifiers
-        names = ['45_degree', '225_degree', '180_degree', '135_degree']
+        names = ['45_degrees', '225_degrees', '180_degrees', '135_degrees']
 
         # create cameras from four points. These cameras look at the centroid.
         default_cameras = []

--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -25,9 +25,6 @@ def export():
 @export.command('export-images')
 @click.argument('hbjson-file')
 @click.option(
-    '--name', '-n', help='Name of image files.', default="Camera", show_default=True
-)
-@click.option(
     '--folder', '-f', help='Path to target folder.',
     type=click.Path(exists=False, file_okay=False, resolve_path=True,
                     dir_okay=True), default='.', show_default=True
@@ -78,7 +75,7 @@ def export():
     show_default=True
 )
 def export(
-        hbjson_file, name, folder, image_type, image_width, image_height,
+        hbjson_file, folder, image_type, image_width, image_height,
         background_color, model_display_mode, grid_options, grid_display_mode, view,
         config):
     """Export images from radiance views in a HBJSON file.
@@ -145,10 +142,10 @@ def export(
         scene = Scene(background_color=background_color)
         scene.add_actors(actors)
 
-        # Set a default camera if there are not cameras in the model
+        # Set a default camera if there are no cameras in the model
         if not model.cameras and not view:
             actors = Actor.from_model(model=model)
-            camera = Camera(type='l')
+            camera = Camera(identifier='plan_view', type='l')
             scene.add_cameras(camera)
             bounds = Actor.get_bounds(actors)
             centroid = Actor.get_centroid(actors)
@@ -172,7 +169,7 @@ def export(
             load_config(config, model, scene)
 
         output = scene.export_images(
-            folder=folder, name=name, image_type=image_type,
+            folder=folder, image_type=image_type,
             image_width=image_width, image_height=image_height)
 
     except Exception:

--- a/honeybee_vtk/scene.py
+++ b/honeybee_vtk/scene.py
@@ -176,8 +176,7 @@ class Scene:
 
     @try_headless
     def export_images(
-            self, folder: str, name: str = 'Camera',
-            image_type: ImageTypes = ImageTypes.png, *,
+            self, folder: str, image_type: ImageTypes = ImageTypes.png, *,
             image_scale: int = 1, image_width: int = 2000, image_height: int = 2000,
             color_range: vtk.vtkLookupTable = None, rgba: bool = False,
             show: bool = False) -> List[str]:
@@ -189,7 +188,6 @@ class Scene:
 
         Args:
             folder: A valid path to where you'd like to write the images.
-            name: Name of the image as a text string.
             image_type: An ImageType object.
             image_scale: An integer value as a scale factor. Defaults to 1.
             image_width: An integer value that sets the width of image in pixels.
@@ -211,10 +209,10 @@ class Scene:
         self.update_scene()
 
         return [assistant._export_image(
-            folder=folder, name=name + '_' + str(count), image_type=image_type,
-            image_scale=image_scale, image_width=image_width, image_height=image_height,
+            folder=folder, image_type=image_type, image_scale=image_scale,
+            image_width=image_width, image_height=image_height,
             color_range=color_range, rgba=rgba, show=show)
-            for count, assistant in enumerate(self._assistants)]
+            for assistant in self._assistants]
 
     def export_gltf(self, folder: str, name: str = 'Camera') -> str:
         """Export a scene to a glTF file.

--- a/tests/local/cli/export_test.py
+++ b/tests/local/cli/export_test.py
@@ -20,13 +20,16 @@ def test_export_image():
 
     result = runner.invoke(
         export, [
-            file_path, '--folder', target_folder, '--name', 'Model', '--image-type',
-            'PNG', '--image-width', 200, '--image-height', 500,
+            file_path, '--folder', target_folder, '--image-type', 'PNG',
+            '--image-width', 500, '--image-height', 500,
             '--background-color', 255, 255, 255, '--grid-options', 'Meshes',
             '--model-display-mode', 'Shaded', '--grid-display-mode', 'SurfaceWithEdges',
             '--view', view_file, '--view', view_file_1, '--config', config_path])
 
     assert result.exit_code == 0
-    images_path = os.listdir(target_folder)
-    assert all([item[:5] == 'Model' and item[-4:] == '.png' for item in images_path])
+    exported_file_names = os.listdir(target_folder)
+    file_names = ['Back.png', 'Bottom.png', 'Front.png',
+                  'Left.png', 'Right.png', 'Top.png', 'view.png', 'view1.png']
+    assert exported_file_names == file_names
+
     nukedir(target_folder, True)

--- a/tests/local/cli/export_test.py
+++ b/tests/local/cli/export_test.py
@@ -30,6 +30,6 @@ def test_export_image():
     exported_file_names = os.listdir(target_folder)
     file_names = ['Back.png', 'Bottom.png', 'Front.png',
                   'Left.png', 'Right.png', 'Top.png', 'view.png', 'view1.png']
-    assert exported_file_names == file_names
+    assert all([name in file_names for name in exported_file_names])
 
     nukedir(target_folder, True)

--- a/tests/local/scene_test.py
+++ b/tests/local/scene_test.py
@@ -55,8 +55,7 @@ def test_export_images_from_view_file():
     os.mkdir(target_folder)
 
     # Export images for all the cameras
-    images_path = scene.export_images(folder=target_folder, image_type=ImageTypes.png,
-                                      name='camera')
+    images_path = scene.export_images(folder=target_folder, image_type=ImageTypes.png)
 
     for path in images_path:
         assert os.path.isfile(path)
@@ -134,8 +133,7 @@ def test_export_images():
     os.mkdir(target_folder)
 
     # Export images for all the cameras
-    images_path = scene.export_images(folder=target_folder, image_type=ImageTypes.png,
-                                      name='camera')
+    images_path = scene.export_images(folder=target_folder, image_type=ImageTypes.png)
 
     for path in images_path:
         assert os.path.isfile(path)


### PR DESCRIPTION
This PR adds default camera names. The default camera names are 'plan_view', '45_degrees', '135_degrees', '180_degrees', '225_degrees'. Also, a radiance view's identifier will be used as image names if radiance views are added to the model.

resolves #193 