### PR TITLE
fix(camera): fix default camera names

### DIFF
--- a/honeybee_vtk/camera.py
+++ b/honeybee_vtk/camera.py
@@ -169,7 +169,7 @@ class Camera(View):
             pt, centroid).v for pt in camera_points]
 
         # default camera identifiers
-        names = ['45_degrees', '225_degrees', '180_degrees', '135_degrees']
+        names = ['45_degrees', '315_degrees', '225_degrees', '135_degrees']
 
         # create cameras from four points. These cameras look at the centroid.
         default_cameras = []

--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -145,7 +145,7 @@ def export(
         # Set a default camera if there are no cameras in the model
         if not model.cameras and not view:
             actors = Actor.from_model(model=model)
-            camera = Camera(identifier='plan_view', type='l')
+            camera = Camera(identifier='plan', type='l')
             scene.add_cameras(camera)
             bounds = Actor.get_bounds(actors)
             centroid = Actor.get_centroid(actors)


### PR DESCRIPTION
default camera names are 'plan', '45_degrees', '135_degrees', '225_degrees', '315_degrees'.