### PR TITLE
Data range in .vtkjs file

### DIFF
--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -341,8 +341,8 @@ def _load_data(folder_path: pathlib.Path, identifier: str, model: Model,
 def _get_legend_range(data: DataConfig) -> List[Union[float, int]]:
     """Read and get legend min and max values from data if provided by the user.
 
-    The value provided by this function is processed in _get_data_range function in the
-    type module.
+    The value provided by this function is processed and validated in _get_data_range 
+    function in the type module.
 
     Args:
         data (DataConfig): A Dataconfig object.
@@ -363,15 +363,7 @@ def _get_legend_range(data: DataConfig) -> List[Union[float, int]]:
         else:
             max = legend_params.max
 
-        if not min and not max:
-            warnings.warn(
-                f'In data {data.identifier.capitalize()}, since min and max'
-                ' values of legend are not provided, those values will be auto'
-                ' calculated based on data. \n'
-            )
         return [min, max]
-    else:
-        return None
 
 
 def _load_legend_parameters(data: DataConfig, model: Model, scene: Scene,
@@ -390,7 +382,10 @@ def _load_legend_parameters(data: DataConfig, model: Model, scene: Scene,
 
     legend.colors = legend_params.color_set
     legend.unit = data.unit
-    legend.min, legend.max = legend_range
+    if legend_range:
+        legend.min, legend.max = legend_range
+    else:
+        legend.min, legend.max = [None, None]
     legend.hide_legend = legend_params.hide_legend
     legend.orientation = legend_params.orientation
     legend.position = legend_params.position

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -5,11 +5,11 @@ import json
 import pathlib
 import warnings
 
-from typing import List, Union
+from typing import List, Union, Tuple
 from pydantic import BaseModel, validator, Field, constr, conint
 from pydantic.types import confloat, conlist
 from .types import DataSetNames
-from .legend_parameter import ColorSets, Text, DecimalCount, Orientation
+from .legend_parameter import ColorSets, Text, DecimalCount, Orientation, LegendParameter
 from .model import Model
 from ._helper import get_line_count, get_min_max
 from .vtkjs.schema import DisplayMode
@@ -142,10 +142,6 @@ class LegendConfig(BaseModel):
 
 class DataConfig(BaseModel):
     """Config for simulation results you'd like to load on a honeybee-vtk model."""
-
-    class Config:
-        validate_all = True
-        validate_assignment = True
 
     identifier: str = Field(
         description='identifier to be given to data. Example, "Daylight-Factor".'
@@ -300,6 +296,7 @@ def _load_data(folder_path: pathlib.Path, identifier: str, model: Model,
         model: A honeybee-vtk model.
         grid_type: A string indicating whether the sensor grid in the model is made of
             points or meshes.
+        legend_range: A tuple of min and max values of the legend parameters.
     """
 
     grids_info_json = folder_path.joinpath('grids_info.json')

--- a/honeybee_vtk/legend_parameter.py
+++ b/honeybee_vtk/legend_parameter.py
@@ -542,7 +542,7 @@ class LegendParameter:
 
     @min.setter
     def min(self, val):
-        if not val:
+        if val == None:
             self._min = None
         elif isinstance(val, (int, float)):
             self._min = val
@@ -557,7 +557,7 @@ class LegendParameter:
 
     @max.setter
     def max(self, val):
-        if not val:
+        if val == None:
             self._max = None
         elif isinstance(val, (int, float)):
             self._max = val
@@ -585,11 +585,11 @@ class LegendParameter:
             )
 
     @property
-    def range(self):
-        if not self._min and not self._max:
+    def range(self) -> Tuple[float, float]:
+        if self._min == None and self._max == None:
             return self._auto_range
 
-        elif self._min and not self._max:
+        elif self._min and self._max == None:
             if self._min < self._auto_range[1]:
                 return (self._min, self._auto_range[1])
             else:
@@ -600,7 +600,7 @@ class LegendParameter:
                     ' provide a max value.'
                 )
 
-        elif not self._min and self._max:
+        elif self._min == None and self._max:
             if self._max > self._auto_range[0]:
                 return (self._auto_range[0], self._max)
             else:
@@ -611,7 +611,7 @@ class LegendParameter:
                     ' provide a min value.'
                 )
 
-        elif self._min and self._max:
+        elif isinstance(self._min, (int, float)) and isinstance(self._max, (int, float)):
             if self._min < self._max:
                 return (self._min, self._max)
             else:

--- a/honeybee_vtk/types.py
+++ b/honeybee_vtk/types.py
@@ -515,9 +515,6 @@ class ModelDataSet:
             data = JoinedPolyData.from_polydata(self.data)
         return _write_to_folder(data, target_folder.as_posix())
 
-    # TODO: export color-range information for each dataset
-    # each dataset has its own information. If we can only have one then we should use
-    # the information for color_by field.
     def as_data_set(self, url=None) -> DataSet:
         """Convert to a vtkjs DataSet object.
 
@@ -540,11 +537,18 @@ class ModelDataSet:
         if self.color_by is not None:
             mapper.colorByArrayName = self.color_by
 
+        # Getting range of each data added to the ModelDataSet object.
+        ranges = {}
+        if self.name == 'Grid' and self.fields_info:
+            for name, value in self.fields_info.items():
+                ranges[name] = value.range
+
         data = {
             'name': self.name,
             'httpDataSetReader': {'url': url if url is not None else self.name},
             'property': ds_prop.dict(),
-            'mapper': mapper.dict()
+            'mapper': mapper.dict(),
+            'data_ranges': ranges
         }
 
         return DataSet.parse_obj(data)

--- a/honeybee_vtk/vtkjs/schema.py
+++ b/honeybee_vtk/vtkjs/schema.py
@@ -1,7 +1,7 @@
 """Schema for VTKJS objects."""
 import json
 import pathlib
-from typing import Dict, List
+from typing import Dict, List, Tuple
 import enum
 
 from pydantic import BaseModel, Field, validator
@@ -82,6 +82,10 @@ class DataSet(BaseModel):
     )
     mapper: DataSetMapper = Field(DataSetMapper())
     property: DataSetProperty = Field(DataSetProperty())
+    data_ranges: Dict[str, Tuple[float, float]] = Field(
+        {},
+        description='range of data for all the data added to the Dataset object.'
+    )
 
 
 class IndexJSON(BaseModel):

--- a/honeybee_vtk/vtkjs/schema.py
+++ b/honeybee_vtk/vtkjs/schema.py
@@ -82,9 +82,9 @@ class DataSet(BaseModel):
     )
     mapper: DataSetMapper = Field(DataSetMapper())
     property: DataSetProperty = Field(DataSetProperty())
-    data_ranges: Dict[str, Tuple[float, float]] = Field(
+    legend_ranges: Dict[str, Tuple[float, float]] = Field(
         {},
-        description='range of data for all the data added to the Dataset object.'
+        description='legned range of data for all the data added to the Dataset object.'
     )
 
 

--- a/tests/assets/config/valid.json
+++ b/tests/assets/config/valid.json
@@ -1,46 +1,38 @@
-
-{ 
-
-"grid": {
-        "identifier": "Daylight-Factor",
-        "object_type": "grid",
-        "unit": "Percentage",
-        "path": "./tests/assets/df_results",
-        "hide": false,
-        "legend_parameters": {
-            "hide_legend": false,
-            "min": 0,
-            "max": 20,
-            "color_set": "original",
-            "position": [0.5, 0.05],
-            "label_parameters": {
-                "color": [34, 247, 10],
-                "size": 0,
-                "bold": true
-            }
-        }
-},
-"grid1": {
+{
+  "grid": {
+    "identifier": "Daylight-Factor",
+    "object_type": "grid",
+    "unit": "Percentage",
+    "path": "./tests/assets/df_results",
+    "hide": false,
+    "legend_parameters": {
+      "hide_legend": false,
+      "min": 0,
+      "max": 20,
+      "color_set": "original",
+      "position": [0.5, 0.05],
+      "label_parameters": {
+        "color": [34, 247, 10],
+        "size": 0,
+        "bold": true
+      }
+    }
+  },
+  "grid1": {
     "identifier": "UDI",
     "object_type": "grid",
     "unit": "Percentage",
     "path": "./tests/assets/udi_results",
     "hide": true,
     "legend_parameters": {
-        "hide_legend": false,
-        "min": 0,
-        "max": 100,
-        "color_set": "nuanced",
-        "position": [0.9, 0.5],
-        "orientation": "vertical",
-        "width": 0.05,
-        "height": 0.45
-
+      "hide_legend": false,
+      "min": 0,
+      "max": 100,
+      "color_set": "nuanced",
+      "position": [0.9, 0.5],
+      "orientation": "vertical",
+      "width": 0.05,
+      "height": 0.45
     }
+  }
 }
-
-
-
-
-}
-

--- a/tests/github/config_test.py
+++ b/tests/github/config_test.py
@@ -136,7 +136,7 @@ def test_data_config_validators():
     """Testing if correct errors are being raised."""
 
     # all required fields missing
-    with pytest.raises(KeyError):
+    with pytest.raises(ValidationError):
         data_config = DataConfig()
 
     # required fields missing
@@ -147,13 +147,13 @@ def test_data_config_validators():
     with pytest.raises(ValidationError):
         data_config = DataConfig(
             identifier='Daylight-factor', object_type='grid', unit='Percentage',
-            folder_path='tests/assets/config/valid.json')
+            path='tests/assets/config/valid.json')
 
     # invalid object type
     with pytest.raises(ValidationError):
         data_config = DataConfig(
             identifier='Daylight-factor', object_type='ground', unit='Percentage',
-            folder_path='tests/assets/df_results')
+            path='tests/assets/df_results')
 
 
 def test_data_config_legend_parameter_validator():
@@ -166,7 +166,7 @@ def test_data_config_legend_parameter_validator():
     with pytest.raises(ValidationError):
         data_config = DataConfig(
             identifier='Daylight-factor', object_type='grid', unit='Percentage',
-            folder_path='tests/assets/df_results', legend_parameters=legend_params)
+            path='tests/assets/df_results', legend_parameters=legend_params)
 
     # height greater than position in Y direction
     legend_params = LegendConfig()
@@ -175,7 +175,7 @@ def test_data_config_legend_parameter_validator():
     with pytest.raises(ValidationError):
         data_config = DataConfig(
             identifier='Daylight-factor', object_type='grid', unit='Percentage',
-            folder_path='tests/assets/df_results', legend_parameters=legend_params)
+            path='tests/assets/df_results', legend_parameters=legend_params)
 
 
 def test_load_legend_parameter():

--- a/tests/github/legend_parameter_test.py
+++ b/tests/github/legend_parameter_test.py
@@ -126,3 +126,17 @@ def test_range():
         lp.min = 10
         lp.max = 5
         lp.range
+
+
+def test_legend_min_max():
+    """Testing how the LegendParameter object treats min and max values."""
+    lp = LegendParameter()
+    lp.min = 0
+    lp.max = 0
+    assert lp.min == 0
+    assert lp.max == 0
+
+    lp.min = None
+    lp.max = None
+    assert lp.min is None
+    assert lp.max is None

--- a/tests/github/schema_test.py
+++ b/tests/github/schema_test.py
@@ -1,0 +1,13 @@
+"""Unit test for the schema module."""
+
+import pytest
+from honeybee_vtk.vtkjs.schema import DataSet, DataSetResource
+
+# TODO: more unit tests to be added to cover the whole schema
+
+
+def test_default_legend_ranges():
+    """Check default values of legend_ranges."""
+    dr = DataSetResource(url='.')
+    ds = DataSet(name='temp', httpDataSetReader=dr)
+    assert ds.legend_ranges == {}


### PR DESCRIPTION
This PR essentially adds data-range to the .vtkjs file so that the front-end can use it. A new object named "data_ranges" is added in the index.json. This object has data-range for all the simulation data added to a Dataset (Say "Grid"). 

![data-ranges](https://user-images.githubusercontent.com/20086924/129615980-fdf173d6-2ad6-4c5e-ac02-e09b12418380.PNG)


If min and max values are provided in the config file, They will find their way here in this data_ranges object. In the image above, the range for "Daylight-Factor" comes from the values set by a user in the config file. Otherwise, an auto-calculated range based on the simulation data will be reported. In the image above, the range for "UDI" is auto-calculated by honeybee-vtk.