### PR TITLE
Make data validation and legend optional

### DIFF
--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -74,10 +74,15 @@ def export():
     ' mount simulation data on HBJSON.', type=click.Path(exists=True), default=None,
     show_default=True
 )
+@click.option(
+    '--validate-data', '-vd', is_flag=True, default=False,
+    help='Validate simulation data before loading on the model. This is recommended'
+    ' when using this command locally.', show_default=True
+)
 def export(
         hbjson_file, folder, image_type, image_width, image_height,
         background_color, model_display_mode, grid_options, grid_display_mode, view,
-        config):
+        config, validate_data):
     """Export images from radiance views in a HBJSON file.
 
     \b
@@ -166,7 +171,10 @@ def export(
 
         # load config if provided
         if config:
-            load_config(config, model, scene)
+            if validate_data:
+                load_config(config, model, scene, validation=True, legend=True)
+            else:
+                load_config(config, model, scene, legend=True)
 
         output = scene.export_images(
             folder=folder, image_type=image_type,

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -210,34 +210,50 @@ class DataConfig(BaseModel):
         return v
 
 
-def _validate_data(data: DataConfig, model: Model) -> str:
+def _get_grid_type(model: Model) -> str:
+    """Get the type of grid in the model
+
+    Args:
+        model(Model): A honeybee-vtk model.
+
+    Returns:
+        A string indicating whether the model has points and meshes.
+    """
+
+    if model.sensor_grids.data[0].GetNumberOfCells() == 1:
+        return 'points'
+    else:
+        return 'meshes'
+
+
+def _validate_simulation_data(data: DataConfig, model: Model, grid_type: str) -> None:
     """Match result data with the sensor grids in the model.
 
     It will be checked if the number of data files and the names of the
     data files match with the grid identifiers. This function does not support validating
-    result data for other than sensor grids as of now. This is a helper method to the
-    public load_config method.
+    result data for other than sensor grids as of now.
+
+    This is a helper method to the public load_config method.
 
     Args:
         data: A DataConfig object.
         model: A honeybee-vtk model.
-
-    Returns:
-        A text representing grid type. 'points' or 'meshes'
+        grid_type: A string indicating whether the model has points and meshes.
     """
+    # file path to the json file
     grids_info_json = pathlib.Path(data.path).joinpath('grids_info.json')
 
+    # read the json file
     with open(grids_info_json) as fh:
         grids_info = json.load(fh)
 
-    assert len(model.sensor_grids.data) > 0, 'Sensor grids are not loaded on'\
-        ' this model. Reload them using grid options.'
     # TODO: Make sure to remove this limitation. A user should not have to always
     # TODO: load all the grids
     assert len(model.sensor_grids.data) == len(grids_info), 'The number of result'\
         f' files {len(grids_info)} does for {data.identifier} does not match'\
         f' the number of sensor grids in the model {len(model.sensor_grids.data)}.'
 
+    # match identifiers of the grids with the identifiers of the result files
     grids_model_identifiers = [grid.identifier for grid in model.sensor_grids.data]
     grids_info_identifiers = [grid['full_id'] for grid in grids_info]
     assert grids_model_identifiers == grids_info_identifiers, 'The identifiers of'\
@@ -249,17 +265,15 @@ def _validate_data(data: DataConfig, model: Model) -> str:
 
     # check if the grid data is meshes or points
     # if grid is sensors
-    if model.sensor_grids.data[0].GetNumberOfCells() == 1 and \
-            model.sensor_grids.data[0].GetNumberOfPoints() == file_lengths[0]:
+    if grid_type == 'points':
         num_sensors = [polydata.GetNumberOfPoints()
                        for polydata in model.sensor_grids.data]
-        grid_type = 'points'
     # if grid is meshes
     else:
         num_sensors = [polydata.GetNumberOfCells()
                        for polydata in model.sensor_grids.data]
-        grid_type = 'meshes'
 
+    # lastly check if the length of a file matches the number of sensors or meshes on grid
     if file_lengths != num_sensors:
         length_matching = {
             grids_info_identifiers[i]: file_lengths[i] == num_sensors[i] for i in
@@ -272,58 +286,58 @@ def _validate_data(data: DataConfig, model: Model) -> str:
             ' Lengths of files with following names do not match'
             f' {tuple(names_to_report)}.')
 
-    return grid_type
 
-
-def _load_data(data: DataConfig, model: Model, grid_type: str) -> None:
+def _load_data(folder_path: pathlib.Path, identifier: str, model: Model,
+               grid_type: str) -> None:
     """Load validated data on a honeybee-vtk model.
 
     This is a helper method to the public load_config method.
 
     Args:
-        data: A DataConfig object.
+        folder_path: A valid pathlib path to the folder with grid_info.json and data.
+        identifier: A text string representing the identifier of the data in the config
+            file.
         model: A honeybee-vtk model.
-        grid_type: A string indicating whether the sensor grid in the model is made of 
+        grid_type: A string indicating whether the sensor grid in the model is made of
             points or meshes.
     """
-    if not data.hide:
-        grids_info_json = pathlib.Path(data.path).joinpath('grids_info.json')
-        with open(grids_info_json) as fh:
-            grids_info = json.load(fh)
 
-        # grid identifier from grids_info.json
-        file_names = [grid['identifier'] for grid in grids_info]
+    grids_info_json = folder_path.joinpath('grids_info.json')
+    with open(grids_info_json) as fh:
+        grids_info = json.load(fh)
 
-        # finding file extension for grid results
-        for path in pathlib.Path(data.path).iterdir():
-            if path.stem == file_names[0]:
-                extension = path.suffix
-                break
+    # grid identifier from grids_info.json
+    file_names = [grid['identifier'] for grid in grids_info]
 
-        # file paths to the result files
-        file_paths = [pathlib.Path(data.path).joinpath(name+extension)
-                      for name in file_names]
+    # finding file extension for grid results
+    for path in folder_path.iterdir():
+        if path.stem == file_names[0]:
+            extension = path.suffix
+            break
 
-        result = []
-        for file_path in file_paths:
-            res_file = pathlib.Path(file_path)
-            grid_res = [float(v)
-                        for v in res_file.read_text().splitlines()]
-            result.append(grid_res)
+    # file paths to the result files
+    file_paths = [folder_path.joinpath(name+extension)
+                  for name in file_names]
 
-        ds = model.get_modeldataset(data.object_type)
-        if grid_type == 'meshes':
-            ds.add_data_fields(
-                result, name=data.identifier, per_face=True)
-            if not data.hide:
-                ds.color_by = data.identifier
-            ds.display_mode = DisplayMode.SurfaceWithEdges
-        else:
-            ds.add_data_fields(
-                result, name=data.identifier, per_face=False)
-            if not data.hide:
-                ds.color_by = data.identifier
-            ds.display_mode = DisplayMode.Points
+    result = []
+    for file_path in file_paths:
+        res_file = pathlib.Path(file_path)
+        grid_res = [float(v)
+                    for v in res_file.read_text().splitlines()]
+        result.append(grid_res)
+
+    ds = model.get_modeldataset(DataSetNames.grid)
+
+    if grid_type == 'meshes':
+        ds.add_data_fields(
+            result, name=identifier, per_face=True)
+        ds.color_by = identifier
+        ds.display_mode = DisplayMode.SurfaceWithEdges
+    else:
+        ds.add_data_fields(
+            result, name=identifier, per_face=False)
+        ds.color_by = identifier
+        ds.display_mode = DisplayMode.Points
 
 
 def _load_legend_parameters(data: DataConfig, model: Model, scene: Scene) -> None:
@@ -334,72 +348,67 @@ def _load_legend_parameters(data: DataConfig, model: Model, scene: Scene) -> Non
         model: A honeybee-vtk model object.
         scene: A honeyebee-vtk scene object.
     """
-    if data.legend_parameters and not data.hide:
+    legend_params = data.legend_parameters
+    legend = scene.legend_parameter(data.identifier)
 
-        legend_params = data.legend_parameters
-        legend = scene.legend_parameter(data.identifier)
+    legend.colors = legend_params.color_set
+    legend.unit = data.unit
 
-        legend.colors = legend_params.color_set
-        legend.unit = data.unit
+    if isinstance(legend_params.min, Autocalculate):
+        legend.min = None
+    else:
+        legend.min = legend_params.min
 
-        if isinstance(legend_params.min, Autocalculate):
-            legend.min = None
-        else:
-            legend.min = legend_params.min
+    if isinstance(legend_params.max, Autocalculate):
+        legend.max = None
+    else:
+        legend.max = legend_params.max
 
-        if isinstance(legend_params.max, Autocalculate):
-            legend.max = None
-        else:
-            legend.max = legend_params.max
-
-        if not legend.min and not legend.max:
-            warnings.warn(
-                f'In data {data.identifier.capitalize()}, since min and max'
-                ' values are not provided, those values will be auto calculated based'
-                ' on data. \n'
-            )
-
-        legend.hide_legend = legend_params.hide_legend
-        legend.orientation = legend_params.orientation
-        legend.position = legend_params.position
-        legend.width = legend_params.width
-        legend.height = legend_params.height
-
-        if isinstance(legend_params.color_count, int):
-            legend.color_count = legend_params.color_count
-        else:
-            legend.color_count = None
-
-        if isinstance(legend_params.label_count, int):
-            legend.label_count = legend_params.label_count
-        else:
-            legend.label_count = None
-
-        legend.decimal_count = legend_params.decimal_count
-        legend.preceding_labels = legend_params.preceding_labels
-
-        label_params = legend_params.label_parameters
-        legend.label_parameters = Text(
-            label_params.color, label_params.size, label_params.bold)
-
-        title_params = legend_params.title_parameters
-        legend.title_parameters = Text(
-            title_params.color, title_params.size, title_params.bold)
-
-    elif data.legend_parameters and data.hide:
+    if not legend.min and not legend.max:
         warnings.warn(
-            f'Since {data.object_type.value.capitalize()} is not going to be'
-            f' colored by {data.identifier}, legend parameters will be ignored. \n'
+            f'In data {data.identifier.capitalize()}, since min and max'
+            ' values are not provided, those values will be auto calculated based'
+            ' on data. \n'
         )
 
+    legend.hide_legend = legend_params.hide_legend
+    legend.orientation = legend_params.orientation
+    legend.position = legend_params.position
+    legend.width = legend_params.width
+    legend.height = legend_params.height
 
-def load_config(json_path: str, model: Model, scene: Scene) -> Model:
+    if isinstance(legend_params.color_count, int):
+        legend.color_count = legend_params.color_count
+    else:
+        legend.color_count = None
+
+    if isinstance(legend_params.label_count, int):
+        legend.label_count = legend_params.label_count
+    else:
+        legend.label_count = None
+
+    legend.decimal_count = legend_params.decimal_count
+    legend.preceding_labels = legend_params.preceding_labels
+
+    label_params = legend_params.label_parameters
+    legend.label_parameters = Text(
+        label_params.color, label_params.size, label_params.bold)
+
+    title_params = legend_params.title_parameters
+    legend.title_parameters = Text(
+        title_params.color, title_params.size, title_params.bold)
+
+
+def load_config(json_path: str, model: Model, scene: Scene,
+                validation: bool = False, legend: bool = False) -> Model:
     """Mount data on model from config json.
 
     Args:
         json_path: File path to the config json file.
         model: A honeybee-vtk model object.
         scene: A honeybee-vtk scene object.
+        validation: A boolean indicating whether to validate the data before loading.
+        legend: A boolean indicating whether to load legend parameters.
 
     Returns:
         A honeybee-vtk model with data loaded on it.
@@ -413,8 +422,28 @@ def load_config(json_path: str, model: Model, scene: Scene) -> Model:
         )
     else:
         for json_obj in config.values():
+            # check if model has grids loaded
+            assert len(model.sensor_grids.data) > 0, 'Sensor grids are not loaded on'\
+                ' this model. Reload them using grid options.'
+            # validate config
             data = DataConfig.parse_obj(json_obj)
-            grid_type = _validate_data(data, model)
-            _load_data(data, model, grid_type)
-            _load_legend_parameters(data, model, scene)
-        return model
+            # if data is requested
+            if not data.hide:
+                folder_path = pathlib.Path(data.path)
+                identifier = data.identifier
+                grid_type = _get_grid_type(model)
+                # Validate data if asked for
+                if validation:
+                    _validate_simulation_data(data, model, grid_type)
+                # Load data
+                _load_data(folder_path, identifier, model, grid_type)
+                # If legend is requested and legend parameters are provided
+                # Legend will only be used in export-images command
+                if legend and data.legend_parameters:
+                    _load_legend_parameters(data, model, scene)
+            else:
+                warnings.warn(
+                    f'Data for {data.identifier} is not loaded.'
+                )
+
+    return model

--- a/tests/assets/dummy_results/identifier_mismatch/grids_info.json
+++ b/tests/assets/dummy_results/identifier_mismatch/grids_info.json
@@ -12,12 +12,5 @@
     "count": 468,
     "group": "",
     "full_id": "TestRoom_y"
-  },
-  {
-    "name": "TestRoom_3",
-    "identifier": "TestRoom_3",
-    "count": 468,
-    "group": "",
-    "full_id": "TestRoom_3"
   }
 ]

--- a/tests/github/cli/translate_test.py
+++ b/tests/github/cli/translate_test.py
@@ -52,3 +52,22 @@ def test_translate_recipe():
     vtkjs_path = os.path.join(target_folder, 'Model.zip')
     assert os.path.isfile(vtkjs_path)
     nukedir(target_folder, True)
+
+
+def test_translate_with_config():
+    """Test translating to vtkjs with config."""
+    runner = CliRunner()
+    file_path = r'tests/assets/gridbased.hbjson'
+    json_path = r'tests/assets/config/valid.json'
+    target_folder = r'tests/target'
+
+    # Optional arguments are deliberately capitalized or uppercased for testing
+    result = runner.invoke(translate, [
+        file_path, '--name', 'Model', '--folder', target_folder, '--file-type',
+        'vtkjs', '--display-mode', 'Shaded', '--grid-options', 'MESHES', '--config',
+        json_path])
+
+    assert result.exit_code == 0
+    html_path = os.path.join(target_folder, 'Model.vtkjs')
+    assert os.path.isfile(html_path)
+    nukedir(target_folder, True)


### PR DESCRIPTION
This PR adds `--validate-data` flag to both the commands. This flag makes simulation data validation optional. Also, since legend is only used in `export-images` command, legend generation and validation is also made optional. 