### PR TITLE
build(requirements): update dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lbt-honeybee>=0.5.23
+lbt-honeybee>=0.5.50
 vtk==9.0.3


### PR DESCRIPTION
There was a bug in the core library that was returning surfaces with holes when a rectangular surface's punched geometry was accessed.

resolves #236 