### PR TITLE
Fix path to the result folders

### DIFF
--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 import json
+import os
 import pathlib
 import warnings
 
@@ -328,7 +329,6 @@ def _load_data(folder_path: pathlib.Path, identifier: str, model: Model,
         legend_range: A list of min and max values of the legend parameters provided by
             the user in the config file.
     """
-
     grids_info_json = folder_path.joinpath('grids_info.json')
     with open(grids_info_json) as fh:
         grids_info = json.load(fh)
@@ -465,6 +465,9 @@ def load_config(json_path: str, model: Model, scene: Scene,
             'Not a valid json file.'
         )
     else:
+        cwd = pathlib.Path.cwd()
+        jwd = pathlib.Path(json_path).absolute().parent
+        os.chdir(jwd)
         for json_obj in config['data']:
             # check if model has grids loaded
             assert len(model.sensor_grids.data) > 0, 'Sensor grids are not loaded on'\
@@ -491,5 +494,5 @@ def load_config(json_path: str, model: Model, scene: Scene,
                 warnings.warn(
                     f'Data for {data.identifier} is not loaded.'
                 )
-
+        os.chdir(cwd)
     return model

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -470,7 +470,7 @@ def load_config(json_path: str, model: Model, scene: Scene,
         for json_obj in config['data']:
             if not pathlib.Path(json_obj['path']).is_dir():
                 # Making all results folders path relative to the config file
-                json_obj['path'] = str(jwd.joinpath(json_obj['path']))
+                json_obj['path'] = jwd.joinpath(json_obj['path']).as_posix()
             # check if model has grids loaded
             assert len(model.sensor_grids.data) > 0, 'Sensor grids are not loaded on'\
                 ' this model. Reload them using grid options.'

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -465,10 +465,13 @@ def load_config(json_path: str, model: Model, scene: Scene,
             'Not a valid json file.'
         )
     else:
-        cwd = pathlib.Path.cwd()
+
+        # cwd = pathlib.Path.cwd()
         jwd = pathlib.Path(json_path).absolute().parent
-        os.chdir(jwd)
         for json_obj in config['data']:
+            if not pathlib.Path(json_obj['path']).is_dir():
+                # Making all results folders path relative to the config file
+                json_obj['path'] = str(jwd.joinpath(json_obj['path']))
             # check if model has grids loaded
             assert len(model.sensor_grids.data) > 0, 'Sensor grids are not loaded on'\
                 ' this model. Reload them using grid options.'
@@ -494,5 +497,4 @@ def load_config(json_path: str, model: Model, scene: Scene,
                 warnings.warn(
                     f'Data for {data.identifier} is not loaded.'
                 )
-        os.chdir(cwd)
     return model

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -465,8 +465,6 @@ def load_config(json_path: str, model: Model, scene: Scene,
             'Not a valid json file.'
         )
     else:
-
-        # cwd = pathlib.Path.cwd()
         jwd = pathlib.Path(json_path).absolute().parent
         for json_obj in config['data']:
             if not pathlib.Path(json_obj['path']).is_dir():

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -465,6 +465,7 @@ def load_config(json_path: str, model: Model, scene: Scene,
             'Not a valid json file.'
         )
     else:
+        # directory where the config file is located
         jwd = pathlib.Path(json_path).absolute().parent
         for json_obj in config['data']:
             if not pathlib.Path(json_obj['path']).is_dir():

--- a/tests/github/config_test.py
+++ b/tests/github/config_test.py
@@ -201,7 +201,7 @@ def test_validate_data_invalid_json():
     invalid_json_path = r'tests/assets/config/invalid.json'
     model = Model.from_hbjson(model_grid_mesh, load_grids=SensorGridOptions.Mesh)
     scene = Scene()
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         load_config(invalid_json_path, model, scene)
 
 


### PR DESCRIPTION
In the config file, if the path to the result folder is relative, the path becomes invalid incase the current working directory of the script is not same as the directory where the config file is. This PR addresses that.