### PR TITLE
fix(config): allow paths relative to config

### DIFF
--- a/honeybee_vtk/types.py
+++ b/honeybee_vtk/types.py
@@ -526,6 +526,7 @@ class ModelDataSet:
         fields_info = self.fields_info
         if not value:
             self._color_by = None
+            return
         else:
             assert value in fields_info, \
                 f'{value} is not a valid data field for this ModelDataSet. Available ' \

--- a/tests/assets/config/valid.json
+++ b/tests/assets/config/valid.json
@@ -11,9 +11,16 @@
         "min": 0,
         "max": 20,
         "color_set": "original",
-        "position": [0.5, 0.05],
+        "position": [
+          0.5,
+          0.05
+        ],
         "label_parameters": {
-          "color": [34, 247, 10],
+          "color": [
+            34,
+            247,
+            10
+          ],
           "size": 0,
           "bold": true
         }
@@ -23,14 +30,37 @@
       "identifier": "UDI",
       "object_type": "grid",
       "unit": "Percentage",
-      "path": "./tests/assets/udi_results",
+      "path": "./tests/assets/df_results",
       "hide": true,
       "legend_parameters": {
         "hide_legend": false,
         "min": 0,
         "max": 100,
         "color_set": "nuanced",
-        "position": [0.9, 0.5],
+        "position": [
+          0.9,
+          0.5
+        ],
+        "orientation": "vertical",
+        "width": 0.05,
+        "height": 0.45
+      }
+    },
+    {
+      "identifier": "Relative Path DF Results",
+      "object_type": "grid",
+      "unit": "Percentage",
+      "path": "../udi_results",
+      "hide": false,
+      "legend_parameters": {
+        "hide_legend": false,
+        "min": 0,
+        "max": 100,
+        "color_set": "nuanced",
+        "position": [
+          0.9,
+          0.5
+        ],
         "orientation": "vertical",
         "width": 0.05,
         "height": 0.45

--- a/tests/assets/config/valid.json
+++ b/tests/assets/config/valid.json
@@ -30,7 +30,7 @@
       "identifier": "UDI",
       "object_type": "grid",
       "unit": "Percentage",
-      "path": "./tests/assets/df_results",
+      "path": "./tests/assets/udi_results",
       "hide": true,
       "legend_parameters": {
         "hide_legend": false,
@@ -50,20 +50,26 @@
       "identifier": "Relative Path DF Results",
       "object_type": "grid",
       "unit": "Percentage",
-      "path": "../udi_results",
+      "path": "../df_results",
       "hide": false,
       "legend_parameters": {
         "hide_legend": false,
         "min": 0,
-        "max": 100,
-        "color_set": "nuanced",
+        "max": 20,
+        "color_set": "original",
         "position": [
-          0.9,
-          0.5
+          0.5,
+          0.05
         ],
-        "orientation": "vertical",
-        "width": 0.05,
-        "height": 0.45
+        "label_parameters": {
+          "color": [
+            34,
+            247,
+            10
+          ],
+          "size": 0,
+          "bold": true
+        }
       }
     }
   ]

--- a/tests/github/types_test.py
+++ b/tests/github/types_test.py
@@ -1,11 +1,10 @@
 """Unit test for the types module."""
 
-import warnings
 import pytest
 import vtk
 from honeybee.model import Model as HBModel
-from honeybee_vtk.types import PolyData, _get_data_range
 from honeybee_vtk.model import Model
+from honeybee_vtk.types import ModelDataSet, PolyData, _get_data_range
 
 file_path = r'tests/assets/gridbased.hbjson'
 hb_model = HBModel.from_hbjson(file_path)
@@ -151,3 +150,12 @@ def test_get_data_range():
     # make sure when string array is used, simply data_range is returned
     values = vtk.vtkStringArray()
     assert _get_data_range('test', [0, 100], values) == (0, 100)
+
+
+def test_model_dataset_initialization_with_polydata():
+    polydata = PolyData()
+    polydata.add_data([1, 2, 3], 'demo-data')
+    md = ModelDataSet('test', [polydata])
+
+    assert md.data == [polydata]
+    assert md._color_by is None


### PR DESCRIPTION
I would personally argue that all file paths should be relative to the config file so that we do not need to call honeybee-vtk from a specific folder but we can have that discussion later :p

re #pollination/streamlit-experiment#14

This also fixes a bug I noticed in #283 