### PR TITLE
Fix translate & export commands

### DIFF
--- a/honeybee_vtk/cli/export.py
+++ b/honeybee_vtk/cli/export.py
@@ -172,9 +172,9 @@ def export(
         # load config if provided
         if config:
             if validate_data:
-                load_config(config, model, scene, validation=True)
+                load_config(config, model, scene, validation=True, legend=True)
             else:
-                load_config(config, model, scene)
+                load_config(config, model, scene, legend=True)
 
         output = scene.export_images(
             folder=folder, image_type=image_type,

--- a/honeybee_vtk/cli/translate.py
+++ b/honeybee_vtk/cli/translate.py
@@ -102,17 +102,10 @@ def translate(
 
         # load data
         if config:
-            scene = Scene()
-            actors = Actor.from_model(model)
-            bounds = Actor.get_bounds(actors)
-            centroid = Actor.get_centroid(actors)
-            cameras = Camera.aerial_cameras(bounds=bounds, centroid=centroid)
-            scene.add_actors(actors)
-            scene.add_cameras(cameras)
             if validate_data:
-                model = load_config(config, model, scene, validation=True)
+                model = load_config(config, model, validation=True)
             else:
-                model = load_config(config, model, scene)
+                model = load_config(config, model)
 
         # Set file type
 

--- a/honeybee_vtk/config.py
+++ b/honeybee_vtk/config.py
@@ -434,14 +434,14 @@ def _load_legend_parameters(data: DataConfig, model: Model, scene: Scene,
         title_params.color, title_params.size, title_params.bold)
 
 
-def load_config(json_path: str, model: Model, scene: Scene,
+def load_config(json_path: str, model: Model, scene: Scene = None,
                 validation: bool = False, legend: bool = False) -> Model:
     """Mount data on model from config json.
 
     Args:
         json_path: File path to the config json file.
         model: A honeybee-vtk model object.
-        scene: A honeybee-vtk scene object.
+        scene: A honeybee-vtk scene object. Defaults to None.
         validation: A boolean indicating whether to validate the data before loading.
         legend: A boolean indicating whether to load legend parameters.
 
@@ -484,7 +484,8 @@ def load_config(json_path: str, model: Model, scene: Scene,
                 # Load data
                 _load_data(folder_path, identifier, model, grid_type, legend_range)
                 # Load legend parameters
-                _load_legend_parameters(data, model, scene, legend_range)
+                if legend:
+                    _load_legend_parameters(data, model, scene, legend_range)
             else:
                 warnings.warn(
                     f'Data for {data.identifier} is not loaded.'

--- a/honeybee_vtk/model.py
+++ b/honeybee_vtk/model.py
@@ -196,7 +196,8 @@ class Model(object):
             if len(ids) == 1:
                 id = model.properties.radiance.sensor_grids[0].identifier
                 sensors = [
-                    sensor for grid in model.properties.radiance.sensor_grids for sensor in grid.sensors]
+                    sensor for grid in model.properties.radiance.sensor_grids
+                    for sensor in grid.sensors]
                 sensor_grid = SensorGrid(id, sensors)
                 self._sensor_grids.data.append(
                     convert_sensor_grid(sensor_grid, grid_options)


### PR DESCRIPTION
- This PR stops loading legend parameters in translate command. Legend parameters are not needed since they are handled by the viewers.
- The legend parameters will be loaded in the export command using the 'legend' argument on the load-config function.
