### PR TITLE
fix(deps): bump lbt-honeybee to 0.5.260

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-lbt-honeybee>=0.5.65
+lbt-honeybee>=0.5.260
 vtk==9.1.0


### PR DESCRIPTION
This will ensure we can parse the models with AirBoundary type correctly.